### PR TITLE
Added a constructor for PoseEstimate with no arguments that has default values

### DIFF
--- a/LimelightHelpers.java
+++ b/LimelightHelpers.java
@@ -443,6 +443,20 @@ public class LimelightHelpers {
         public double avgTagArea;
         public RawFiducial[] rawFiducials; 
 
+        /**
+         * Makes a PoseEstimate object with default values
+         */
+        public PoseEstimate() {
+            this.pose = new Pose2d();
+            this.timestampSeconds = 0;
+            this.latency = 0;
+            this.tagCount = 0;
+            this.tagSpan = 0;
+            this.avgTagDist = 0;
+            this.avgTagArea = 0;
+            this.rawFiducials = new RawFiducial[]{};
+        }
+
         public PoseEstimate(Pose2d pose, double timestampSeconds, double latency, 
             int tagCount, double tagSpan, double avgTagDist, 
             double avgTagArea, RawFiducial[] rawFiducials) {
@@ -456,6 +470,7 @@ public class LimelightHelpers {
             this.avgTagArea = avgTagArea;
             this.rawFiducials = rawFiducials;
         }
+
     }
 
     private static ObjectMapper mapper;


### PR DESCRIPTION
My team added this small thing to make empty PoseEstimate objects for when our robot was first powering on.