### PR TITLE
Add more NT Functionality

### DIFF
--- a/LimelightHelpers.java
+++ b/LimelightHelpers.java
@@ -489,7 +489,7 @@ public class LimelightHelpers {
         return name;
     }
 
-    private static Pose3d toPose3D(double[] inData){
+    public static Pose3d toPose3D(double[] inData){
         if(inData.length < 6)
         {
             //System.err.println("Bad LL 3D Pose Data!");
@@ -501,7 +501,7 @@ public class LimelightHelpers {
                     Units.degreesToRadians(inData[5])));
     }
 
-    private static Pose2d toPose2D(double[] inData){
+    public static Pose2d toPose2D(double[] inData){
         if(inData.length < 6)
         {
             //System.err.println("Bad LL 2D Pose Data!");
@@ -510,6 +510,40 @@ public class LimelightHelpers {
         Translation2d tran2d = new Translation2d(inData[0], inData[1]);
         Rotation2d r2d = new Rotation2d(Units.degreesToRadians(inData[5]));
         return new Pose2d(tran2d, r2d);
+    }
+
+    /**
+     * Converts a Pose3d object to an array of doubles.
+     * 
+     * @param pose The Pose3d object to convert.
+     * @return The array of doubles representing the pose.
+     **/
+    public static double[] pose3dToArray(Pose3d pose) {
+        double[] result = new double[6];
+        result[0] = pose.getTranslation().getX();
+        result[1] = pose.getTranslation().getY();
+        result[2] = pose.getTranslation().getZ();
+        result[3] = Units.radiansToDegrees(pose.getRotation().getX());
+        result[4] = Units.radiansToDegrees(pose.getRotation().getY());
+        result[5] = Units.radiansToDegrees(pose.getRotation().getZ());
+        return result;
+    }
+
+    /**
+     * Converts a Pose2d object to an array of doubles.
+     * 
+     * @param pose The Pose2d object to convert.
+     * @return The array of doubles representing the pose.
+     **/
+    public static double[] pose2dToArray(Pose2d pose) {
+        double[] result = new double[6];
+        result[0] = pose.getTranslation().getX();
+        result[1] = pose.getTranslation().getY();
+        result[2] = 0;
+        result[3] = Units.radiansToDegrees(0);
+        result[4] = Units.radiansToDegrees(0);
+        result[5] = Units.radiansToDegrees(pose.getRotation().getRadians());
+        return result;
     }
 
     private static double extractArrayEntry(double[] inData, int position){
@@ -624,7 +658,7 @@ public class LimelightHelpers {
         return rawDetections;
     }
 
-    private static void printPoseEstimate(PoseEstimate pose) {
+    public static void printPoseEstimate(PoseEstimate pose) {
         if (pose == null) {
             System.out.println("No PoseEstimate available.");
             return;


### PR DESCRIPTION
Allow users to read and write to NT more easily for logging and replaying.

`toLog`
```
table.put(
            "estimatedPose/" + Integer.toString(posePosition),
            LimelightHelpers.pose2dToArray(poseEstimate.pose()));
```


`fromLog`
```
Pose2d poseEstimation =
            LimelightHelpers.toPose2D(
                table.get("estimatedPose/" + Integer.toString(i), new double[] {}));
```