### PR TITLE
Add MegaTag2 Checker to PoseEstimate

### DIFF
--- a/LimelightHelpers.java
+++ b/LimelightHelpers.java
@@ -449,6 +449,7 @@ public class LimelightHelpers {
         public double avgTagDist;
         public double avgTagArea;
         public RawFiducial[] rawFiducials; 
+        public boolean isMegaTag2;
 
         /**
          * Makes a PoseEstimate object with default values
@@ -462,11 +463,12 @@ public class LimelightHelpers {
             this.avgTagDist = 0;
             this.avgTagArea = 0;
             this.rawFiducials = new RawFiducial[]{};
+            this.isMegaTag2 = false;
         }
 
         public PoseEstimate(Pose2d pose, double timestampSeconds, double latency, 
             int tagCount, double tagSpan, double avgTagDist, 
-            double avgTagArea, RawFiducial[] rawFiducials) {
+            double avgTagArea, RawFiducial[] rawFiducials, boolean isMegaTag2) {
 
             this.pose = pose;
             this.timestampSeconds = timestampSeconds;
@@ -476,6 +478,7 @@ public class LimelightHelpers {
             this.avgTagDist = avgTagDist;
             this.avgTagArea = avgTagArea;
             this.rawFiducials = rawFiducials;
+            this.isMegaTag2 = isMegaTag2;
         }
 
     }
@@ -559,7 +562,7 @@ public class LimelightHelpers {
         return inData[position];
     }
 
-    private static PoseEstimate getBotPoseEstimate(String limelightName, String entryName) {
+    private static PoseEstimate getBotPoseEstimate(String limelightName, String entryName, boolean isMegaTag2) {
         DoubleArrayEntry poseEntry = LimelightHelpers.getLimelightDoubleArrayEntry(limelightName, entryName);
         
         TimestampedDoubleArray tsValue = poseEntry.getAtomic();
@@ -601,7 +604,7 @@ public class LimelightHelpers {
             }
         }
     
-        return new PoseEstimate(pose, adjustedTimestamp, latency, tagCount, tagSpan, tagDist, tagArea, rawFiducials);
+        return new PoseEstimate(pose, adjustedTimestamp, latency, tagCount, tagSpan, tagDist, tagArea, rawFiducials, isMegaTag2);
     }
 
     private static RawFiducial[] getRawFiducials(String limelightName) {
@@ -676,6 +679,7 @@ public class LimelightHelpers {
         System.out.printf("Tag Span: %.2f meters%n", pose.tagSpan);
         System.out.printf("Average Tag Distance: %.2f meters%n", pose.avgTagDist);
         System.out.printf("Average Tag Area: %.2f%% of image%n", pose.avgTagArea);
+        System.out.printf("Is MegaTag2: %b%n", pose.isMegaTag2);
         System.out.println();
     
         if (pose.rawFiducials == null || pose.rawFiducials.length == 0) {
@@ -696,6 +700,10 @@ public class LimelightHelpers {
             System.out.printf("  Ambiguity: %.2f%n", fiducial.ambiguity);
             System.out.println();
         }
+    }
+
+    public static Boolean validPoseEstimate(PoseEstimate pose) {
+        return pose != null && pose.rawFiducials != null && pose.rawFiducials.length != 0;
     }
 
     public static NetworkTable getLimelightNTTable(String tableName) {
@@ -971,7 +979,7 @@ public class LimelightHelpers {
      * @return
      */
     public static PoseEstimate getBotPoseEstimate_wpiBlue(String limelightName) {
-        return getBotPoseEstimate(limelightName, "botpose_wpiblue");
+        return getBotPoseEstimate(limelightName, "botpose_wpiblue", false);
     }
 
     /**
@@ -982,7 +990,7 @@ public class LimelightHelpers {
      * @return
      */
     public static PoseEstimate getBotPoseEstimate_wpiBlue_MegaTag2(String limelightName) {
-        return getBotPoseEstimate(limelightName, "botpose_orb_wpiblue");
+        return getBotPoseEstimate(limelightName, "botpose_orb_wpiblue", true);
     }
 
     /**
@@ -1006,7 +1014,7 @@ public class LimelightHelpers {
      * @return
      */
     public static PoseEstimate getBotPoseEstimate_wpiRed(String limelightName) {
-        return getBotPoseEstimate(limelightName, "botpose_wpired");
+        return getBotPoseEstimate(limelightName, "botpose_wpired", false);
     }
 
     /**
@@ -1016,7 +1024,7 @@ public class LimelightHelpers {
      * @return
      */
     public static PoseEstimate getBotPoseEstimate_wpiRed_MegaTag2(String limelightName) {
-        return getBotPoseEstimate(limelightName, "botpose_orb_wpired");
+        return getBotPoseEstimate(limelightName, "botpose_orb_wpired", true);
     }
 
     /**


### PR DESCRIPTION
Many people use MegaTag1 when the robot is disabled (to get a starting pose) and MegaTag2 when enabled, which can lead to the following code structure.
```
LimelightHelpers.SetRobotOrientation(
    limelightName, swerveStateSupplier.get().Pose.getRotation().getDegrees(), 0, 0, 0, 0, 0);
PoseEstimate mt =
    DriverStation.isEnabled()
        ? LimelightHelpers.getBotPoseEstimate_wpiBlue(limelightName)
        : LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(limelightName);
```
followed by
```
double thetaStdDev = DriverStation.isEnabled() ? calculateThetaStdDev(mt) : 9999999;
```
This can lead to issues where `DriverStation.isEnabled()` returns different values (if on different threads), and MegaTag2 rotation is trusted. Due to the current MegaTag2 rotation should not be trusted if used. This would allow you to change the second block of code to.
```
double thetaStdDev = mt.isMegaTag2 ? calculateThetaStdDev(mt) : 9999999;
```

This pull request also adds a small helper function to check if a `PoseEstimate` is valid. 